### PR TITLE
Add OpenRouter profile routing backend

### DIFF
--- a/config/mission.yaml
+++ b/config/mission.yaml
@@ -56,14 +56,14 @@ model_classes:
     json_mode: true
 
 tier_model_classes:
-  root: "root_judge"
+  root: "openrouter_reasoning"
   tier_1: "senior_judge"
   tier_2: "compliance"
   tier_3: "coordinator"
   tier_4: "leaf_executor"
 
 tribe_model_classes:
-  moses: "root_judge"
+  moses: "openrouter_reasoning"
   judah: "senior_judge"
   levi: "senior_judge"
   dan: "senior_judge"

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,3 +56,27 @@ COI_RUN_LIVE_OLLAMA=1 uv run --extra dev pytest tests/test_orchestrator_api_inte
 ```
 
 If Ollama is unavailable, the test reports a typed runtime failure path rather than treating local setup as a code regression.
+
+## Agentic OS Runtime Routing
+
+Agentic OS repo-delivery runs use profile routing by default:
+
+- Moses/root intake uses the `openrouter_reasoning` model class.
+- Lower Jethro tiers keep the local Ollama classes from `config/mission.yaml`.
+- If `OPENROUTER_API_KEY` is not set, the OpenRouter profile falls back to mock output with explicit runtime metadata.
+
+Live OpenRouter usage:
+
+```bash
+export OPENROUTER_API_KEY="..."
+export AGENTIC_OS_COI_BACKEND=profile
+export AGENTIC_OS_OPENROUTER_MODEL="openrouter/auto"
+```
+
+Force one backend when debugging:
+
+```bash
+AGENTIC_OS_COI_BACKEND=mock .venv/bin/python -m pytest -q tests/test_agentic_os_runner.py
+AGENTIC_OS_COI_BACKEND=ollama .venv/bin/python -m pytest -q tests/test_agentic_os_runner.py
+AGENTIC_OS_COI_BACKEND=openrouter OPENROUTER_API_KEY="..." .venv/bin/python -m coi_api.agentic_os_runner --request /path/to/request.json
+```

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -19,6 +19,16 @@ uv run coi-demo --task examples/tasks/local_bootstrap.task.json --output-dir .co
 5. emit `task-run`, `execution-log`, and `result-bundle` artifacts
 6. return a shell-facing summary that ScheduleOS can render
 
+## Agentic OS profile routing
+
+When `agentic-os` invokes `coi_api.agentic_os_runner`, the default backend is profile-routed:
+
+- `moses` resolves to `openrouter_reasoning` and provider `openrouter`.
+- lower execution tribes resolve to the configured Ollama model classes.
+- missing OpenRouter credentials do not hide the route; the worker id becomes `moses:openrouter-mock-fallback` and output metadata records `provider=openrouter`, `model=openrouter/auto`, and `fallback=mock`.
+
+Set `OPENROUTER_API_KEY` to make Moses use the live OpenRouter chat-completions adapter. Use `AGENTIC_OS_COI_BACKEND=mock`, `ollama`, `openrouter`, or `profile` to force a backend while debugging.
+
 ## Output layout
 
 - `task.json`

--- a/packages/orchestrator/src/coi_orchestrator/agentic_os_engine.py
+++ b/packages/orchestrator/src/coi_orchestrator/agentic_os_engine.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from typing import Any, Iterator, TypedDict
 
 from coi_contracts import RunStatus, WorkerRequest, new_id, to_jsonable, utc_now
-from coi_runtime import MockRuntimeBackend, OllamaRuntimeBackend, RuntimeBackend
+from coi_runtime import (
+    MockRuntimeBackend,
+    OllamaRuntimeBackend,
+    OpenRouterRuntimeBackend,
+    ProfileRoutingRuntimeBackend,
+    RuntimeBackend,
+)
 from coi_runtime.profiles import TierRuntimeProfile, load_tier_profiles
 
 try:  # pragma: no cover - LangGraph is optional in the local deterministic path.
@@ -453,14 +459,22 @@ def _approval_policy(value: Any) -> dict[str, str]:
 def _default_backend() -> RuntimeBackend:
     backend_name = os.environ.get("AGENTIC_OS_COI_BACKEND", "auto").strip().lower()
     model = os.environ.get("AGENTIC_OS_OLLAMA_MODEL") or os.environ.get("OLLAMA_MODEL") or "qwen2.5-coder:1.5b"
+    openrouter_model = os.environ.get("AGENTIC_OS_OPENROUTER_MODEL") or os.environ.get("OPENROUTER_MODEL") or "openrouter/auto"
+    openrouter = OpenRouterRuntimeBackend(
+        model=openrouter_model,
+        referer=os.environ.get("OPENROUTER_HTTP_REFERER") or os.environ.get("OPENROUTER_SITE_URL"),
+        title=os.environ.get("OPENROUTER_APP_TITLE") or "agentic-os",
+    )
     ollama = OllamaRuntimeBackend(model=model)
     if backend_name == "mock":
         return MockRuntimeBackend(name="agentic-os-mock")
+    if backend_name == "profile":
+        return ProfileRoutingRuntimeBackend(openrouter=openrouter)
+    if backend_name == "openrouter":
+        return openrouter
     if backend_name == "ollama":
         return ollama
-    if ollama.available():
-        return ollama
-    return MockRuntimeBackend(name="agentic-os-mock-fallback")
+    return ProfileRoutingRuntimeBackend(openrouter=openrouter)
 
 
 def _write_stage_artifact(

--- a/packages/runtime/src/coi_runtime/__init__.py
+++ b/packages/runtime/src/coi_runtime/__init__.py
@@ -1,4 +1,11 @@
-from .backends import HermesRuntimeAdapter, MockRuntimeBackend, OllamaRuntimeBackend, RuntimeBackend
+from .backends import (
+    HermesRuntimeAdapter,
+    MockRuntimeBackend,
+    OllamaRuntimeBackend,
+    OpenRouterRuntimeBackend,
+    ProfileRoutingRuntimeBackend,
+    RuntimeBackend,
+)
 from .profiles import JETHRO_TIERS, TRIBE_TIERS, ModelClassPolicy, TierRuntimeProfile, load_tier_profiles
 
 __all__ = [
@@ -7,6 +14,8 @@ __all__ = [
     "ModelClassPolicy",
     "MockRuntimeBackend",
     "OllamaRuntimeBackend",
+    "OpenRouterRuntimeBackend",
+    "ProfileRoutingRuntimeBackend",
     "RuntimeBackend",
     "TierRuntimeProfile",
     "TRIBE_TIERS",

--- a/packages/runtime/src/coi_runtime/backends.py
+++ b/packages/runtime/src/coi_runtime/backends.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 from urllib import error, request
 
@@ -118,6 +119,98 @@ class OllamaRuntimeBackend:
 
 
 @dataclass(slots=True)
+class OpenRouterRuntimeBackend:
+    model: str = "openrouter/auto"
+    endpoint: str = "https://openrouter.ai/api/v1/chat/completions"
+    api_key: str | None = None
+    timeout_seconds: float = 60.0
+    referer: str | None = None
+    title: str = "children-of-israel-agent-swarm"
+    name: str = "openrouter"
+
+    def available(self) -> bool:
+        return bool(self._api_key())
+
+    def for_model(self, model: str) -> "OpenRouterRuntimeBackend":
+        return OpenRouterRuntimeBackend(
+            model=model or self.model,
+            endpoint=self.endpoint,
+            api_key=self.api_key,
+            timeout_seconds=self.timeout_seconds,
+            referer=self.referer,
+            title=self.title,
+            name=self.name,
+        )
+
+    def execute(self, worker_request: WorkerRequest) -> WorkerResult:
+        api_key = self._api_key()
+        if not api_key:
+            return WorkerResult(
+                request_id=worker_request.request_id,
+                run_id=worker_request.run_id,
+                worker_id=f"{worker_request.tribe_id}:openrouter",
+                status=RunStatus.FAILED,
+                failure=RuntimeFailure(
+                    code="openrouter_missing_api_key",
+                    message="OPENROUTER_API_KEY is required for the OpenRouter runtime backend.",
+                    retryable=False,
+                    details={"endpoint": self.endpoint, "model": self.model},
+                ),
+            )
+
+        body = json.dumps(
+            {
+                "model": self.model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a Children of Israel runtime worker. "
+                            "Return one JSON object with summary, confidence, and artifacts."
+                        ),
+                    },
+                    {"role": "user", "content": json.dumps(_worker_prompt(worker_request))},
+                ],
+                "temperature": 0,
+            }
+        ).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        if self.referer:
+            headers["HTTP-Referer"] = self.referer
+        if self.title:
+            headers["X-OpenRouter-Title"] = self.title
+
+        try:
+            req = request.Request(self.endpoint, data=body, headers=headers, method="POST")
+            with request.urlopen(req, timeout=self.timeout_seconds) as response:
+                raw = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            return _failed_openrouter_result(worker_request, self, _http_error_message(exc), retryable=True)
+        except Exception as exc:  # noqa: BLE001 - adapter failures become typed runtime failures.
+            return _failed_openrouter_result(worker_request, self, str(exc), retryable=True)
+
+        output = _normalise_output(_openrouter_output(raw))
+        output["_runtime"] = {
+            "provider": "openrouter",
+            "model": raw.get("model", self.model) if isinstance(raw, dict) else self.model,
+            "usage": raw.get("usage", {}) if isinstance(raw, dict) else {},
+        }
+        return WorkerResult(
+            request_id=worker_request.request_id,
+            run_id=worker_request.run_id,
+            worker_id=f"{worker_request.tribe_id}:openrouter",
+            status=RunStatus.SUCCEEDED,
+            output=output,
+        )
+
+    def _api_key(self) -> str:
+        return (self.api_key if self.api_key is not None else os.environ.get("OPENROUTER_API_KEY", "")).strip()
+
+
+@dataclass(slots=True)
 class HermesRuntimeAdapter:
     binary: str = "hermes"
     timeout_seconds: float = 120.0
@@ -192,7 +285,147 @@ class HermesRuntimeAdapter:
         )
 
 
+@dataclass(slots=True)
+class ProfileRoutingRuntimeBackend:
+    openrouter: OpenRouterRuntimeBackend = field(default_factory=OpenRouterRuntimeBackend)
+    mock: MockRuntimeBackend = field(default_factory=lambda: MockRuntimeBackend(name="profile-mock-fallback"))
+    ollama_endpoint: str = "http://127.0.0.1:11434/api/generate"
+    ollama_timeout_seconds: float = 30.0
+    name: str = "profile-routing"
+
+    def available(self) -> bool:
+        return True
+
+    def execute(self, worker_request: WorkerRequest) -> WorkerResult:
+        profile = _parse_runtime_profile_id(worker_request.runtime_profile_id)
+        provider = profile.get("provider", "")
+        model = profile.get("model", "")
+        if provider == "openrouter":
+            backend = self.openrouter.for_model(model)
+            return (
+                backend.execute(worker_request)
+                if backend.available()
+                else _provider_mock_fallback(worker_request, self.mock, provider, model)
+            )
+        if provider == "ollama":
+            backend = OllamaRuntimeBackend(
+                model=model or "llama3.2",
+                endpoint=self.ollama_endpoint,
+                timeout_seconds=self.ollama_timeout_seconds,
+            )
+            return (
+                backend.execute(worker_request)
+                if backend.available()
+                else _provider_mock_fallback(worker_request, self.mock, provider, model)
+            )
+        return _provider_mock_fallback(worker_request, self.mock, provider or "unknown", model)
+
+
 def _normalise_output(output: object) -> dict[str, object]:
     if isinstance(output, dict):
         return output
     return {"summary": str(output), "raw_output": output, "confidence": 0.5}
+
+
+def _worker_prompt(worker_request: WorkerRequest) -> dict[str, object]:
+    return {
+        "mandate": worker_request.mandate,
+        "task_type": worker_request.task_type,
+        "tribe_id": worker_request.tribe_id,
+        "tier": worker_request.tier.value,
+        "prompt": worker_request.prompt,
+        "payload": worker_request.payload,
+        "required_format": {
+            "summary": "string",
+            "confidence": "number",
+            "artifacts": "array",
+        },
+    }
+
+
+def _openrouter_output(raw: object) -> object:
+    if not isinstance(raw, dict):
+        return {"summary": str(raw), "confidence": 0.5}
+    choices = raw.get("choices")
+    first = choices[0] if isinstance(choices, list) and choices else {}
+    message = first.get("message") if isinstance(first, dict) else {}
+    content = message.get("content") if isinstance(message, dict) else None
+    if isinstance(content, dict):
+        return content
+    if isinstance(content, list):
+        content = "\n".join(str(part.get("text", part)) for part in content if isinstance(part, dict))
+    if isinstance(content, str):
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            return {"summary": content, "confidence": 0.5}
+    return {"summary": "", "confidence": 0.0}
+
+
+def _failed_openrouter_result(
+    worker_request: WorkerRequest,
+    backend: OpenRouterRuntimeBackend,
+    message: str,
+    *,
+    retryable: bool,
+) -> WorkerResult:
+    return WorkerResult(
+        request_id=worker_request.request_id,
+        run_id=worker_request.run_id,
+        worker_id=f"{worker_request.tribe_id}:openrouter",
+        status=RunStatus.FAILED,
+        failure=RuntimeFailure(
+            code="openrouter_unavailable",
+            message=message,
+            retryable=retryable,
+            details={"endpoint": backend.endpoint, "model": backend.model},
+        ),
+    )
+
+
+def _provider_mock_fallback(
+    worker_request: WorkerRequest,
+    mock: MockRuntimeBackend,
+    provider: str,
+    model: str,
+) -> WorkerResult:
+    result = mock.execute(worker_request)
+    output = dict(result.output)
+    output["_runtime"] = {
+        "provider": provider,
+        "model": model,
+        "fallback": "mock",
+        "reason": "provider_unavailable",
+    }
+    return WorkerResult(
+        request_id=result.request_id,
+        run_id=result.run_id,
+        worker_id=f"{worker_request.tribe_id}:{provider}-mock-fallback",
+        status=result.status,
+        output=output,
+        events=result.events,
+        failure=result.failure,
+    )
+
+
+def _http_error_message(exc: error.HTTPError) -> str:
+    try:
+        body = exc.read().decode("utf-8")
+    except Exception:  # noqa: BLE001 - best effort diagnostic.
+        body = ""
+    return body or str(exc)
+
+
+def _parse_runtime_profile_id(profile_id: str | None) -> dict[str, str]:
+    if not profile_id:
+        return {}
+    parts = profile_id.split(":", 3)
+    if len(parts) != 4:
+        return {}
+    tribe_id, model_class, provider, model = parts
+    return {
+        "tribe_id": tribe_id,
+        "model_class": model_class,
+        "provider": provider,
+        "model": model,
+    }

--- a/tests/test_agentic_os_runner.py
+++ b/tests/test_agentic_os_runner.py
@@ -52,7 +52,10 @@ def test_agentic_os_runner_streams_jethro_repo_delivery_events(tmp_path):
     assert approval_gates == ["implementation"]
     assert dispatched
     assert all(event["stage"] != "implementation" for event in dispatched)
-    assert all(event["model_policy"]["provider"] == "ollama" for event in dispatched)
+    providers_by_stage = {event["stage"]: event["model_policy"]["provider"] for event in dispatched}
+    assert providers_by_stage["intake"] == "openrouter"
+    assert providers_by_stage["spec"] == "ollama"
+    assert providers_by_stage["plan"] == "ollama"
     completed_artifact_paths = [
         event["payload"]["artifact"]["relative_path"]
         for event in events
@@ -68,6 +71,8 @@ def test_model_policy_resolves_jethro_tiers_and_preserves_legacy_routing():
     profiles = load_tier_profiles(REPO_ROOT / "config" / "mission.yaml")
 
     assert profiles["moses"].tier.value == "root"
+    assert profiles["moses"].model_class == "openrouter_reasoning"
+    assert profiles["moses"].provider == "openrouter"
     assert profiles["judah"].model_class == "senior_judge"
     assert profiles["simeon"].model_class == "compliance"
     assert profiles["reuben"].model_class == "leaf_executor"

--- a/tests/test_openrouter_runtime_backend.py
+++ b/tests/test_openrouter_runtime_backend.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from coi_contracts import RunStatus, Tier, WorkerRequest
+from coi_orchestrator import agentic_os_engine as engine_module
+from coi_runtime import OpenRouterRuntimeBackend, ProfileRoutingRuntimeBackend
+from coi_runtime.profiles import load_tier_profiles
+
+
+def _worker_request() -> WorkerRequest:
+    return WorkerRequest(
+        request_id="worker_openrouter_pytest",
+        run_id="run_openrouter_pytest",
+        tribe_id="moses",
+        tier=Tier.ROOT,
+        task_type="agentic_os.repo_delivery.intake",
+        mandate="Clarify and route this task.",
+        prompt="Return a JSON summary.",
+        payload={"repo_path": "/tmp/repo", "stage": "intake"},
+        runtime_profile_id="moses:openrouter_reasoning:openrouter:openrouter/auto",
+    )
+
+
+class _FakeResponse:
+    status = 200
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_openrouter_backend_sends_chat_completion_and_parses_json(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(request: Any, timeout: float):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(request.header_items())
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        return _FakeResponse(
+            {
+                "model": "openai/gpt-5.2",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17},
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(
+                                {
+                                    "summary": "Moses clarified the task.",
+                                    "confidence": 0.92,
+                                    "artifacts": [],
+                                }
+                            )
+                        }
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr("coi_runtime.backends.request.urlopen", fake_urlopen)
+
+    backend = OpenRouterRuntimeBackend(
+        api_key="test-openrouter-key",
+        model="openrouter/auto",
+        referer="https://davidlifschitz.github.io",
+        title="agentic-os",
+        timeout_seconds=12,
+    )
+    result = backend.execute(_worker_request())
+
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["timeout"] == 12
+    assert captured["headers"]["Authorization"] == "Bearer test-openrouter-key"
+    assert captured["headers"]["Http-referer"] == "https://davidlifschitz.github.io"
+    assert captured["headers"]["X-openrouter-title"] == "agentic-os"
+    assert captured["body"]["model"] == "openrouter/auto"
+    assert captured["body"]["messages"][0]["role"] == "system"
+    assert captured["body"]["messages"][1]["role"] == "user"
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.worker_id == "moses:openrouter"
+    assert result.output["summary"] == "Moses clarified the task."
+    assert result.output["_runtime"]["provider"] == "openrouter"
+    assert result.output["_runtime"]["model"] == "openai/gpt-5.2"
+    assert result.output["_runtime"]["usage"]["total_tokens"] == 17
+
+
+def test_openrouter_backend_reports_missing_api_key_without_http_call(monkeypatch):
+    def fail_urlopen(*_: object, **__: object):
+        raise AssertionError("OpenRouter backend should not make HTTP requests without an API key")
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr("coi_runtime.backends.request.urlopen", fail_urlopen)
+
+    result = OpenRouterRuntimeBackend(api_key="").execute(_worker_request())
+
+    assert result.status == RunStatus.FAILED
+    assert result.failure is not None
+    assert result.failure.code == "openrouter_missing_api_key"
+    assert result.failure.retryable is False
+
+
+def test_default_backend_selects_openrouter_when_requested(monkeypatch):
+    monkeypatch.setenv("AGENTIC_OS_COI_BACKEND", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("AGENTIC_OS_OPENROUTER_MODEL", "openrouter/auto")
+
+    backend = engine_module._default_backend()
+
+    assert backend.name == "openrouter"
+
+
+def test_default_backend_auto_uses_profile_routing(monkeypatch):
+    monkeypatch.delenv("AGENTIC_OS_COI_BACKEND", raising=False)
+
+    backend = engine_module._default_backend()
+
+    assert backend.name == "profile-routing"
+
+
+def test_profile_routing_openrouter_fallback_is_explicit(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    backend = ProfileRoutingRuntimeBackend(openrouter=OpenRouterRuntimeBackend(api_key=""))
+
+    result = backend.execute(_worker_request())
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.worker_id == "moses:openrouter-mock-fallback"
+    assert result.output["_runtime"]["provider"] == "openrouter"
+    assert result.output["_runtime"]["fallback"] == "mock"
+    assert result.output["_runtime"]["reason"] == "provider_unavailable"
+
+
+def test_mission_routes_moses_to_openrouter_reasoning_and_keeps_leaf_tiers_local():
+    profiles = load_tier_profiles("config/mission.yaml")
+
+    assert profiles["moses"].model_class == "openrouter_reasoning"
+    assert profiles["moses"].provider == "openrouter"
+    assert profiles["moses"].model == "openrouter/auto"
+    assert profiles["reuben"].provider == "ollama"
+    assert profiles["reuben"].model_class == "leaf_executor"


### PR DESCRIPTION
## Summary
- add an OpenRouter chat-completions runtime backend and profile-routing backend
- route Moses/root intake to the existing openrouter_reasoning model class while keeping lower tiers on Ollama profiles
- document Agentic OS runtime env vars and explicit no-key mock fallback behavior

## Verification
- `.venv/bin/python -m pytest -q`
- `agentic-os`: `npm run validate:all` via Node v24 PATH
- live dashboard smoke at `http://127.0.0.1:4720/#run-console` shows `openrouter:openrouter/auto`, `moses:openrouter-mock-fallback`, and `reason=provider_unavailable`